### PR TITLE
google access token 발급 로직 제작

### DIFF
--- a/src/entities/signin/ui/GoogleButton.tsx
+++ b/src/entities/signin/ui/GoogleButton.tsx
@@ -3,7 +3,8 @@ import { cn } from '@/shared/utils/cn';
 
 const GoogleButton = () => {
   return (
-    <button
+    <a
+      href={`${process.env.NEXT_PUBLIC_GOOGLE_LOGIN_URL}`}
       className={cn(
         'flex',
         'w-full',
@@ -20,7 +21,7 @@ const GoogleButton = () => {
       >
         Google 계정으로 시작하기
       </span>
-    </button>
+    </a>
   );
 };
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,42 @@
+import axios from 'axios';
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export async function middleware(request: NextRequest) {
+  const response = NextResponse.next();
+  const code = request.nextUrl.searchParams.get('code');
+
+  if (!code) return response;
+
+  const data = new URLSearchParams();
+  data.append('code', code);
+  data.append('client_id', `${process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID}`);
+  data.append(
+    'client_secret',
+    `${process.env.NEXT_PUBLIC_GOOGLE_CLIENT_SECRET}`,
+  );
+  data.append('redirect_uri', `${process.env.NEXT_PUBLIC_GOOGLE_REDIRECT_URI}`);
+  data.append('grant_type', 'authorization_code');
+
+  const tokenInfo = await postToken(data);
+
+  if (!tokenInfo)
+    return NextResponse.redirect(new URL('/signin', request.nextUrl));
+}
+
+const postToken = async (data: URLSearchParams) => {
+  try {
+    const tokenInfo = await axios.post<{ data: { access_token: string } }>(
+      'https://oauth2.googleapis.com/token',
+      data,
+      { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } },
+    );
+    return tokenInfo;
+  } catch {
+    return null;
+  }
+};
+
+export const config = {
+  matcher: '/signup',
+};


### PR DESCRIPTION
## 💡 배경 및 개요

google access token 발급 로직 제작

원래는 로그인 전체 로직을 구현하려고 했으나 아직 서버 배포가 되지 않아 google 로그인 access token 발급 조직까지만 제작 하였습니다

## 📃 작업내용

- middleware를 사용하여 구글 계정 선택후 리다이렉트 과정에서 access token을 발급 받도록 제작
