### PR TITLE
미들웨어 설정 진행

### DIFF
--- a/src/app/api/signin/route.ts
+++ b/src/app/api/signin/route.ts
@@ -45,14 +45,14 @@ export async function GET(request: Request) {
     cookies().set('accessToken', accessToken, {
       httpOnly: true,
       secure: true,
-      sameSite: 'strict',
+      sameSite: 'lax',
       maxAge: Number.MAX_SAFE_INTEGER,
     });
 
     cookies().set('refreshToken', refreshToken, {
       httpOnly: true,
       secure: true,
-      sameSite: 'strict',
+      sameSite: 'lax',
       maxAge: Number.MAX_SAFE_INTEGER,
     });
 

--- a/src/app/api/signup/route.ts
+++ b/src/app/api/signup/route.ts
@@ -18,14 +18,14 @@ export async function POST(request: Request) {
     cookies().set('accessToken', response.data.accessToken, {
       httpOnly: true,
       secure: true,
-      sameSite: 'strict',
+      sameSite: 'lax',
       maxAge: Number.MAX_SAFE_INTEGER,
     });
 
     cookies().set('refreshToken', response.data.refreshToken, {
       httpOnly: true,
       secure: true,
-      sameSite: 'strict',
+      sameSite: 'lax',
       maxAge: Number.MAX_SAFE_INTEGER,
     });
 

--- a/src/app/callback/page.tsx
+++ b/src/app/callback/page.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const page = () => {
+  return <div>로그인 리다렉트 url</div>;
+};
+
+export default page;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -10,9 +10,7 @@ export async function middleware(request: NextRequest) {
   }
 
   const publicPaths = ['/signin', '/callback'];
-  const isPublicPath = publicPaths.some((path) =>
-    request.nextUrl.pathname.startsWith(path),
-  );
+  const isPublicPath = publicPaths.includes(request.nextUrl.pathname);
 
   const accessToken = request.cookies.get('accessToken')?.value;
   const refreshToken = request.cookies.get('refreshToken')?.value;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,17 +3,44 @@ import type { NextRequest } from 'next/server';
 
 export async function middleware(request: NextRequest) {
   const code = request.nextUrl.searchParams.get('code');
-
-  if (!code) {
-    return NextResponse.next();
+  if (code) {
+    const callbackUrl = new URL('/api/signin', request.nextUrl.origin);
+    callbackUrl.searchParams.set('code', code);
+    return NextResponse.redirect(callbackUrl);
   }
 
-  const callbackUrl = new URL('/api/signin', request.nextUrl.origin);
-  callbackUrl.searchParams.set('code', code);
+  const publicPaths = ['/signin', '/callback'];
+  const isPublicPath = publicPaths.some((path) =>
+    request.nextUrl.pathname.startsWith(path),
+  );
 
-  return NextResponse.redirect(callbackUrl);
+  const accessToken = request.cookies.get('accessToken')?.value;
+  const refreshToken = request.cookies.get('refreshToken')?.value;
+
+  if (!isPublicPath && !accessToken && !refreshToken) {
+    return NextResponse.redirect(new URL('/signin', request.url));
+  }
+
+  if (isPublicPath && accessToken && refreshToken) {
+    return NextResponse.redirect(new URL('/stage', request.url));
+  }
+
+  return NextResponse.next();
 }
 
 export const config = {
-  matcher: '/signup',
+  matcher: [
+    '/callback',
+    '/signup',
+    '/stage',
+    '/community/:path*',
+    '/mini-game/:path*',
+    '/stage/:path*',
+    '/team/:path*',
+    '/faq',
+    '/match/:path*',
+    '/my/:path*',
+    '/ranking/:path*',
+    '/signin',
+  ],
 };


### PR DESCRIPTION
## 💡 배경 및 개요
- 미들웨어 설정 진행

## 📃 작업내용
- public path가 아닌데 accessToken과 refreshToken이 없을 때 path에 접근하면 signin으로 리다이렉트 진행
- accessToken과 refreshToken가 있지만 public path에 접속시 /stage로 리다이렉트 진행

## 🔀 변경사항
- 기존에 구글 oath2를 사용하여 코드를 받고 백엔드에게 토큰을 받고 저장을 하여 같은 도메인에서 진행된다고 판단하여 sameSite를 strict로 설정했으나 구글 오어쓰의 다른 도메인에서의 get 진행으로 인해 strict 사용시 리다이렉트 이후 middleware에서 토큰을 감지하지 못해 /signin으로 이동되는 문제가 발생하여 sameSite을 lax로 설정


## 🎸 기타

- lax자체가 어느정도의 csrf 문제를 막아주지만 다른 도메인의 get 요청은 허용하기 때문에 어느정도의 주의가 필요함
- 코드 테스트 진행시 middleware의 많은 테스트 필요
