### PR TITLE
header icon size 36 -> 24px로 반영

### DIFF
--- a/src/shared/ui/header/index.tsx
+++ b/src/shared/ui/header/index.tsx
@@ -52,6 +52,7 @@ const Header = () => {
             >
               <div className={cn('laptop:hidden', 'block')}>
                 <item.icon
+                  size={24}
                   color={
                     hoveredItem === item.href ? '#fff' : getColor(item.href)
                   }


### PR DESCRIPTION
## 💡 배경 및 개요

header icon size 36 -> 24px로 반영

## 📃 작업내용

header icon size 36 -> 24px로 반영

![스크린샷 2025-04-01 오후 8 02 13](https://github.com/user-attachments/assets/ec3efdaa-b7a9-430a-9a24-b11ee86054c7)
