### PR TITLE
관리자 초대 모달 학생 아이디 누락 이슈 해결

### DIFF
--- a/src/shared/ui/InviteStudentInput/index.tsx
+++ b/src/shared/ui/InviteStudentInput/index.tsx
@@ -56,6 +56,10 @@ const InviteStudentInput = forwardRef<InviteStudentInputRef, Props>(
     };
 
     const handleCloseModal = () => {
+      setValue(
+        'maintainer',
+        selectedStudents.map((student) => student.studentId),
+      );
       setIsModalOpen(false);
     };
 

--- a/src/views/stage/create/model/useStageForm.ts
+++ b/src/views/stage/create/model/useStageForm.ts
@@ -74,7 +74,6 @@ export const useStageForm = (formType: 'fast' | 'official') => {
     }
 
     const formattedData = formatStageCreateData(data, formType);
-
     officialStage(formattedData);
   };
 


### PR DESCRIPTION
## 💡 배경 및 개요
관리자 초대 모달 학생 아이디 누락 이슈 해결

## 📃 작업내용
- 기존에 학생 초대 모달을 활성화하고 뒤에 배경을 눌러서 모달을 닫으면 maintain이 전송이 안되는 이슈가 생김
- 초대 모달을 활성화 하고 사람을 선택하고 확인을 누른뒤 다시 모달을 활성화하고 뒤에 배경을 눌러서 닫으면 maintain이 id로 전송되는것이 아닌 이름으로 전송됨

## 🔀 변경사항
close 모달에 id를 설정하는 부분을 추가함
