### PR TITLE
결승 turn이 0인 매치 데이터를 삭제

### DIFF
--- a/src/widgets/stage/time/ui/SetTimeContainer/index.tsx
+++ b/src/widgets/stage/time/ui/SetTimeContainer/index.tsx
@@ -293,14 +293,10 @@ const SetTimeContainer = ({
           JSON.stringify(modifiedSavedMatches),
         );
       } else if (system === GameSystem.TOURNAMENT) {
-        console.log('이상한거 지우기 전 ', savedMatches);
         const modifiedSavedMatches = savedMatches.filter(
           (match) => !(match.round === '결승' && match.index === 0),
         );
-        console.log(
-          '이상한거 지운 후 modifiedSavedMatches',
-          modifiedSavedMatches,
-        );
+
         console.log(
           '부전승',
           sessionStorage.getItem(`threeTeamBye_${matchId}`),

--- a/src/widgets/stage/time/ui/SetTimeContainer/index.tsx
+++ b/src/widgets/stage/time/ui/SetTimeContainer/index.tsx
@@ -293,7 +293,17 @@ const SetTimeContainer = ({
           JSON.stringify(modifiedSavedMatches),
         );
       } else if (system === GameSystem.TOURNAMENT) {
-        console.log('토너먼트 savedMatches', savedMatches);
+        const modifiedSavedMatches = savedMatches.filter(
+          (match) => !(match.round === '결승' && match.index === 0),
+        );
+        console.log(
+          '이상한거 지운 후 modifiedSavedMatches',
+          modifiedSavedMatches,
+        );
+        sessionStorage.setItem(
+          savedMatchesKey,
+          JSON.stringify(modifiedSavedMatches),
+        );
       }
       formatMatchData(matchId, savedMatches);
     }

--- a/src/widgets/stage/time/ui/SetTimeContainer/index.tsx
+++ b/src/widgets/stage/time/ui/SetTimeContainer/index.tsx
@@ -167,11 +167,11 @@ const SetTimeContainer = ({
             if (!finalsMatch) {
               savedMatches.push({
                 round: '결승',
-                index: 0,
+                index: 1,
                 startDate: startDateStr,
                 endDate: endDateStr,
-                teamAName: teamAName, // 4강 승자가 될 팀
-                teamBName: byeTeam.teamName, // 부전승 팀
+                teamAName: 'TBD',
+                teamBName: byeTeam.teamName,
               });
             }
           }
@@ -293,12 +293,17 @@ const SetTimeContainer = ({
           JSON.stringify(modifiedSavedMatches),
         );
       } else if (system === GameSystem.TOURNAMENT) {
+        console.log('이상한거 지우기 전 ', savedMatches);
         const modifiedSavedMatches = savedMatches.filter(
           (match) => !(match.round === '결승' && match.index === 0),
         );
         console.log(
           '이상한거 지운 후 modifiedSavedMatches',
           modifiedSavedMatches,
+        );
+        console.log(
+          '부전승',
+          sessionStorage.getItem(`threeTeamBye_${matchId}`),
         );
         sessionStorage.setItem(
           savedMatchesKey,

--- a/src/widgets/stage/time/ui/SetTimeContainer/index.tsx
+++ b/src/widgets/stage/time/ui/SetTimeContainer/index.tsx
@@ -50,8 +50,11 @@ const SetTimeContainer = ({
     round: string;
     index: number;
   } | null>(null);
-  const [savedMatches, setSavedMatches] =
-    useState<SavedMatchData[]>(initialSavedMatches);
+  const [savedMatches, setSavedMatches] = useState<SavedMatchData[]>(
+    initialSavedMatches.filter(
+      (match) => !(match.round === '결승' && match.index === 0),
+    ),
+  );
   const [matches, setMatches] = useState<{
     quarterFinals: MatchData[];
     semiFinals: MatchData[];
@@ -289,6 +292,8 @@ const SetTimeContainer = ({
           savedMatchesKey,
           JSON.stringify(modifiedSavedMatches),
         );
+      } else if (system === GameSystem.TOURNAMENT) {
+        console.log('토너먼트 savedMatches', savedMatches);
       }
       formatMatchData(matchId, savedMatches);
     }


### PR DESCRIPTION
## 💡 배경 및 개요

결승 turn이 0인 매치 데이터를 강제로 삭제하도록 했습니다.

turn이 0인 경우 서버에서 정산할 때 심각한 오류가 나온다고 해서 우선적으로 수정했습니다.