### PR TITLE
야바위 컵 선택 3초 제한 기능 제작

### DIFF
--- a/src/entities/mini-game/yavarwee/ui/YavarweeAnimation/index.tsx
+++ b/src/entities/mini-game/yavarwee/ui/YavarweeAnimation/index.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import React, { useEffect, useRef, useState } from 'react';
 import { cn } from '@/shared/utils/cn';
 
@@ -32,6 +30,7 @@ const CUP_WIDTH = 210;
 const CUP_HEIGHT = 210;
 const BALL_SIZE = 75;
 const CUP_SPACING = 240;
+const SELECTION_TIMER_DURATION = 3000; // 3 seconds in milliseconds
 
 interface CupState {
   x: number;
@@ -67,6 +66,7 @@ const YavarweeAnimation = ({
   const ballImageRef = useRef<HTMLImageElement | null>(null);
   const animationFrameRef = useRef<number>(0);
   const lastTimeRef = useRef<number>(0);
+  const [timerProgress, setTimerProgress] = useState<number>(100);
 
   const cupCoordinates = [
     { x: CANVAS_WIDTH / 2 - CUP_SPACING },
@@ -113,6 +113,33 @@ const YavarweeAnimation = ({
     visible: false,
     scale: 1,
   });
+
+  useEffect(() => {
+    if (gameState === 'selecting') {
+      setTimerProgress(100);
+    }
+  }, [gameState]);
+
+  useEffect(() => {
+    let timerInterval: NodeJS.Timeout | null = null;
+
+    if (gameState === 'selecting' && userSelection === null) {
+      // Update timer every 30ms for smooth animation
+      const updateInterval = 30;
+      const decrementAmount = (updateInterval / SELECTION_TIMER_DURATION) * 100;
+
+      timerInterval = setInterval(() => {
+        setTimerProgress((prev) => {
+          const newProgress = Math.max(0, prev - decrementAmount);
+          return newProgress;
+        });
+      }, updateInterval);
+    }
+
+    return () => {
+      if (timerInterval) clearInterval(timerInterval);
+    };
+  }, [gameState, userSelection]);
 
   useEffect(() => {
     const cupImage = new Image();
@@ -311,6 +338,12 @@ const YavarweeAnimation = ({
     }
   };
 
+  const getTimerColor = () => {
+    if (timerProgress > 66) return 'bg-green-500';
+    if (timerProgress > 33) return 'bg-yellow-500';
+    return 'bg-red-500';
+  };
+
   return (
     <div
       className={cn(
@@ -332,7 +365,16 @@ const YavarweeAnimation = ({
         className={cn('max-w-full')}
       />
 
-      <div className={cn('z-10', 'mt-4', 'text-center')}>
+      <div
+        className={cn(
+          'z-10',
+          'mt-4',
+          'space-y-16',
+          'text-center',
+          'w-full',
+          'px-4',
+        )}
+      >
         {[
           'betting',
           'showing',
@@ -361,6 +403,22 @@ const YavarweeAnimation = ({
               getStatusText()
             )}
           </p>
+        )}
+
+        {gameState === 'selecting' && userSelection === null && (
+          <div className="mx-auto mt-2 h-10 w-full max-w-[500px] overflow-hidden rounded-sm bg-gray-600">
+            <div
+              className={cn(
+                'h-2.5',
+                'transition-all',
+                'duration-75',
+                getTimerColor(),
+              )}
+              style={{
+                width: `${timerProgress}%`,
+              }}
+            />
+          </div>
         )}
       </div>
 

--- a/src/entities/mini-game/yavarwee/ui/YavarweeAnimation/index.tsx
+++ b/src/entities/mini-game/yavarwee/ui/YavarweeAnimation/index.tsx
@@ -30,7 +30,7 @@ const CUP_WIDTH = 210;
 const CUP_HEIGHT = 210;
 const BALL_SIZE = 75;
 const CUP_SPACING = 240;
-const SELECTION_TIMER_DURATION = 3000; // 3 seconds in milliseconds
+const SELECTION_TIMER_DURATION = 3000;
 
 interface CupState {
   x: number;
@@ -124,7 +124,6 @@ const YavarweeAnimation = ({
     let timerInterval: NodeJS.Timeout | null = null;
 
     if (gameState === 'selecting' && userSelection === null) {
-      // Update timer every 30ms for smooth animation
       const updateInterval = 30;
       const decrementAmount = (updateInterval / SELECTION_TIMER_DURATION) * 100;
 

--- a/src/entities/mini-game/yavarwee/ui/YavarweeButton/index.tsx
+++ b/src/entities/mini-game/yavarwee/ui/YavarweeButton/index.tsx
@@ -20,7 +20,9 @@ const YavarweeButton = ({
         if (onClick) onClick();
       }}
       bg="bg-black-800 hover:bg-main-600"
-      border="border-white hover:border-main-600"
+      border={
+        isPending ? 'border-transparent' : 'border-white hover:border-main-600'
+      }
       disabled={isPending}
     >
       {number}

--- a/src/entities/mini-game/yavarwee/ui/YavarweeButton/index.tsx
+++ b/src/entities/mini-game/yavarwee/ui/YavarweeButton/index.tsx
@@ -4,9 +4,15 @@ interface YavarweeButtonProps {
   number: '1' | '2' | '3';
   onBet: (value: '1' | '2' | '3') => void;
   onClick?: () => void;
+  isPending: boolean;
 }
 
-const YavarweeButton = ({ number, onBet, onClick }: YavarweeButtonProps) => {
+const YavarweeButton = ({
+  number,
+  onBet,
+  onClick,
+  isPending,
+}: YavarweeButtonProps) => {
   return (
     <Button
       onClick={() => {
@@ -15,6 +21,7 @@ const YavarweeButton = ({ number, onBet, onClick }: YavarweeButtonProps) => {
       }}
       bg="bg-black-800 hover:bg-main-600"
       border="border-white hover:border-main-600"
+      disabled={isPending}
     >
       {number}
     </Button>

--- a/src/views/mini-game/yavarwee/ui/YavarweePage/index.tsx
+++ b/src/views/mini-game/yavarwee/ui/YavarweePage/index.tsx
@@ -86,10 +86,10 @@ const YavarweePage = () => {
 
   const getShuffleCountForRound = (round: number): number => {
     const ranges: Record<number, [number, number]> = {
-      1: [10, 12],
-      2: [12, 16],
-      3: [16, 20],
-      4: [20, 25],
+      1: [12, 16],
+      2: [16, 20],
+      3: [20, 25],
+      4: [25, 30],
       5: [35, 45],
     };
 
@@ -99,11 +99,11 @@ const YavarweePage = () => {
 
   const getShuffleAnimationDurationForRound = (round: number): number => {
     const durations: Record<number, number> = {
-      1: 1000,
-      2: 800,
-      3: 600,
-      4: 400,
-      5: 300,
+      1: 800,
+      2: 600,
+      3: 400,
+      4: 300,
+      5: 200,
     };
 
     return durations[round] || 1000;


### PR DESCRIPTION
## 💡 배경 및 개요
야바위 컵 선택 3초 제한 기능 제작

https://github.com/user-attachments/assets/8ab9affa-5bed-4d68-94a3-b750efd766b4


## 📃 작업내용
밸런스를 맞추기 위해 컴의 회전 속도를 변경하였다.
기존에 야바위 셔플이 끝나고 제한 시간이 없어 여러 우려 사항이 발생 하였다. 이러한 문제를 해결하기 위해 셔플이 끝난 후 3초안에 선택하지 않으면 게임이 종료하도록 제작하였다.

추가적으로 ispending을 적용하였다.
