### PR TITLE
야바위 타이머 컴포넌트 언마운트시 타이머 불일치 이슈 해결

### DIFF
--- a/src/entities/mini-game/yavarwee/ui/YavarweeAnimation/index.tsx
+++ b/src/entities/mini-game/yavarwee/ui/YavarweeAnimation/index.tsx
@@ -67,6 +67,7 @@ const YavarweeAnimation = ({
   const animationFrameRef = useRef<number>(0);
   const lastTimeRef = useRef<number>(0);
   const [timerProgress, setTimerProgress] = useState<number>(100);
+  const timerStartTimeRef = useRef<number | null>(null);
 
   const cupCoordinates = [
     { x: CANVAS_WIDTH / 2 - CUP_SPACING },
@@ -116,29 +117,30 @@ const YavarweeAnimation = ({
 
   useEffect(() => {
     if (gameState === 'selecting') {
+      const now = Date.now();
+      timerStartTimeRef.current = now;
       setTimerProgress(100);
+
+      const updateInterval = 30;
+
+      const interval = setInterval(() => {
+        const elapsedTime = Date.now() - (timerStartTimeRef.current || now);
+        const remainingTime = Math.max(
+          0,
+          SELECTION_TIMER_DURATION - elapsedTime,
+        );
+        const newProgress = (remainingTime / SELECTION_TIMER_DURATION) * 100;
+
+        setTimerProgress(newProgress);
+
+        if (remainingTime <= 0) {
+          clearInterval(interval);
+        }
+      }, updateInterval);
+
+      return () => clearInterval(interval);
     }
   }, [gameState]);
-
-  useEffect(() => {
-    let timerInterval: NodeJS.Timeout | null = null;
-
-    if (gameState === 'selecting' && userSelection === null) {
-      const updateInterval = 30;
-      const decrementAmount = (updateInterval / SELECTION_TIMER_DURATION) * 100;
-
-      timerInterval = setInterval(() => {
-        setTimerProgress((prev) => {
-          const newProgress = Math.max(0, prev - decrementAmount);
-          return newProgress;
-        });
-      }, updateInterval);
-    }
-
-    return () => {
-      if (timerInterval) clearInterval(timerInterval);
-    };
-  }, [gameState, userSelection]);
 
   useEffect(() => {
     const cupImage = new Image();


### PR DESCRIPTION
## 💡 배경 및 개요

### 변경 전
https://github.com/user-attachments/assets/e1569cd4-1265-4883-98e6-1525d480b6c5

### 변경 후
https://github.com/user-attachments/assets/981cb10e-9786-4467-9853-ccc255a461e6

## 📃 작업내용
컴포넌트 언 마운트시 백그라운드에서 돌아가는 타이머와 실제 표시되는 게이지바의 타이머가 불일치하는 문제를 개선함

## 🔀 변경사항

기존의 타이머 작동 방식 
1. 백그라운드 타이머:
  - setTimeout을 사용하여 3초 후 게임을 자동 종료
  - 이 타이머는 컴포넌트가 언마운트되어도 계속 실행되어 정상적으로 종료됨
 2. 게이지 바:
  - useEffect와 setInterval을 사용하여 30ms마다 timerProgress를 감소시켜 게이지 바를 업데이트
 
기존 방식의 문제점
1. 상태 초기화
 - 페이지 이동시 컴포넌트가 언바운트 되면서 timerProgress 상태가 초기화
 - 컴포넌트가 다시 마운트될 때, 이전 타이머 진행 상황을 반영하지 못함
2. 시간 계산 오차
 - 백그라운드에서 실행되는 setTimeout과 게이지 바의 setInterval은 서로 독립적으로 작동하므로, 페이지 이동 후 재마운트 시 두 타이머 간의 불일치가 발생
 
개선된 작동 방식
1. 타이머 시작 시간 기록
 - gameState가 'selecting'으로 변경될 때 현재 시간을 useRef로 저장
2. 경과 시간 계산
 - 컴포넌트가 다시 마운트될 때 현재 시간과 시작 시간을 비교하여 경과 시간을 계산
3. 게이지 바 업데이트
 - 매 30ms마다 남은 시간을 계산하여 timerProgress를 업데이트

