### PR TITLE
팀 자세히보기 페이지에서 map이 줄어들지 않도록 수정

### DIFF
--- a/src/entities/match/detail/ui/DetailFormation/index.tsx
+++ b/src/entities/match/detail/ui/DetailFormation/index.tsx
@@ -346,8 +346,9 @@ const DetailFormation = ({
           <div
             className={`relative h-[30rem] w-full`}
             style={{
-              maxWidth: isModalUsed ? '660px' : isLargeScreen ? 'none' : '100%',
-              minWidth: isModalUsed ? '660px' : '780px',
+              maxWidth: isModalUsed ? '660px' : '1200px',
+              minWidth: isModalUsed ? '660px' : '1200px',
+              width: isModalUsed ? '660px' : '1200px',
               margin: '0 auto',
               overflow: 'hidden',
             }}


### PR DESCRIPTION
## 💡 배경 및 개요

팀 자세히보기 페이지에서 map이 줄어들지 않도록 수정했습니다

## 📃 작업내용

![image](https://github.com/user-attachments/assets/37c62622-61c2-413c-ae9c-9cc33d0722ca)