### PR TITLE
6팀 SEMI_FINALS turn 2의 경우에만 승리 확인이 안되는 문제 

### DIFF
--- a/src/shared/ui/BracketTeamDisplay/index.tsx
+++ b/src/shared/ui/BracketTeamDisplay/index.tsx
@@ -298,7 +298,7 @@ const BracketTeamDisplay = ({
                   teamId = getTeamByRoundAndTurn('SEMI_FINALS', 1, 'B');
                   teamName = getTeamNameByRoundAndTurn('SEMI_FINALS', 1, 'B');
                 }
-              } else {
+              } else if (side === 'right') {
                 if (teamCount === 3 && idx === 0) {
                   teamId = getTeamByRoundAndTurn('FINALS', 1, 'B');
                   teamName = getTeamNameByRoundAndTurn('FINALS', 1, 'B');
@@ -323,6 +323,13 @@ const BracketTeamDisplay = ({
             if (teamId) {
               const winner = getWinnerTeamId(round || '', idx);
               isWinner = winner?.id === teamId;
+
+              if (round === 'SEMI_FINALS' && side === 'right' && idx === 0) {
+                const winner = getWinnerTeamId('SEMI_FINALS', 2);
+                if (winner && winner.id === teamId) {
+                  isWinner = true;
+                }
+              }
             }
 
             return (


### PR DESCRIPTION
## 💡 배경 및 개요

6팀 SEMI_FINALS turn 2 매치 특수 처리

## 📃 작업내용

![image](https://github.com/user-attachments/assets/8db19dcf-b0ae-4dff-bd30-accfb362ac6c)
