### PR TITLE
feat: 랭킹 페이지 무한 스크롤 개선

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "react-dom": "^18",
         "react-hook-form": "^7.54.2",
         "react-toastify": "^11.0.5",
+        "scrolloop": "^0.5.2",
         "tailwind-merge": "^3.0.2",
         "tailwindcss-animate": "^1.0.7",
         "zod": "^3.24.2",
@@ -65,6 +66,129 @@
         "prettier-plugin-tailwindcss": "^0.6.10",
         "tailwindcss": "^3.4.1",
         "typescript": "^5.4.2"
+      }
+    },
+    "../../../../private/tmp/scrolloop/packages/core": {
+      "name": "@scrolloop/core",
+      "version": "0.1.0",
+      "extraneous": true,
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^2.0.0",
+        "tsup": "^8.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^2.0.0"
+      }
+    },
+    "../../../../private/tmp/scrolloop/packages/react": {
+      "name": "@scrolloop/react",
+      "version": "0.2.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "@scrolloop/core": "workspace:*",
+        "@scrolloop/shared": "workspace:*"
+      },
+      "devDependencies": {
+        "@playwright/test": "^1.57.0",
+        "@testing-library/jest-dom": "^6.0.0",
+        "@testing-library/react": "^14.0.0",
+        "@testing-library/user-event": "^14.0.0",
+        "@types/express": "^4.17.21",
+        "@types/react": "^18.2.0",
+        "@types/react-dom": "^18.2.0",
+        "@vitest/coverage-v8": "^2.0.0",
+        "esbuild": "^0.27.2",
+        "express": "^4.18.2",
+        "jsdom": "^24.0.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "tsup": "^8.0.0",
+        "tsx": "^4.7.0",
+        "typescript": "^5.0.0",
+        "vitest": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "../../../../private/tmp/scrolloop/packages/shared": {
+      "name": "@scrolloop/shared",
+      "version": "0.1.0",
+      "extraneous": true,
+      "license": "MIT",
+      "devDependencies": {
+        "react": "^18.2.0",
+        "tsup": "^8.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0"
+      }
+    },
+    "../scrolloop/packages/core": {
+      "name": "@scrolloop/core",
+      "version": "0.1.0",
+      "extraneous": true,
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^2.0.0",
+        "tsup": "^8.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^2.0.0"
+      }
+    },
+    "../scrolloop/packages/react": {
+      "name": "@scrolloop/react",
+      "version": "0.2.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "@scrolloop/core": "workspace:*",
+        "@scrolloop/shared": "workspace:*"
+      },
+      "devDependencies": {
+        "@playwright/test": "^1.57.0",
+        "@testing-library/jest-dom": "^6.0.0",
+        "@testing-library/react": "^14.0.0",
+        "@testing-library/user-event": "^14.0.0",
+        "@types/express": "^4.17.21",
+        "@types/react": "^18.2.0",
+        "@types/react-dom": "^18.2.0",
+        "@vitest/coverage-v8": "^2.0.0",
+        "esbuild": "^0.27.2",
+        "express": "^4.18.2",
+        "jsdom": "^24.0.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "tsup": "^8.0.0",
+        "tsx": "^4.7.0",
+        "typescript": "^5.0.0",
+        "vitest": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "../scrolloop/packages/shared": {
+      "name": "@scrolloop/shared",
+      "version": "0.1.0",
+      "extraneous": true,
+      "license": "MIT",
+      "devDependencies": {
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^14.3.1",
+        "jsdom": "^24.1.3",
+        "react": "^18.2.0",
+        "tsup": "^8.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -9153,6 +9277,26 @@
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/scrolloop": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/scrolloop/-/scrolloop-0.5.2.tgz",
+      "integrity": "sha512-XWG8NfCWt1I3CfvQqjvy8wVfcIVkZtt6T39a9ju3qywIxchyYYe+/TAKeCadgfckItYe9IeElRGbf87oDk/ANw==",
+      "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
+      "peerDependencies": {
+        "react": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/semver": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react-dom": "^18",
     "react-hook-form": "^7.54.2",
     "react-toastify": "^11.0.5",
+    "scrolloop": "^0.5.2",
     "tailwind-merge": "^3.0.2",
     "tailwindcss-animate": "^1.0.7",
     "zod": "^3.24.2",

--- a/src/views/ranking/ui/RankingPage/index.tsx
+++ b/src/views/ranking/ui/RankingPage/index.tsx
@@ -1,48 +1,108 @@
 'use client';
 
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import dynamic from 'next/dynamic';
 import { useParams } from 'next/navigation';
 import React, {
   useCallback,
   useEffect,
   useLayoutEffect,
+  useMemo,
   useRef,
   useState,
   CSSProperties,
 } from 'react';
 import { RankingUserItem } from '@/entities/ranking';
-import { RankItem, RankingData } from '@/shared/types/ranking';
+import { RankItem } from '@/shared/types/ranking';
 import BackPageButton from '@/shared/ui/backPageButton';
 import { cn } from '@/shared/utils/cn';
 import { TopRankListContainer } from '@/widgets/ranking';
 import { getRank } from '../../api/getRank';
-import type { PageResponse } from 'scrolloop';
 
 const MemoRankingUserItem = React.memo(RankingUserItem);
 
-const InfiniteList = dynamic(
-  () => import('scrolloop').then((mod) => mod.InfiniteList),
+const VirtualList = dynamic(
+  () => import('scrolloop').then((mod) => mod.VirtualList),
   { ssr: false },
-) as <T>(props: import('scrolloop').InfiniteListProps<T>) => JSX.Element;
+);
 
 const ITEM_HEIGHT = 76;
 const PAGE_SIZE = 10;
+const ALL_PAGE_SIZE = 200;
 const MIN_LIST_HEIGHT = 300;
 const LIST_BOTTOM_GAP = 24;
 const SKIP_TOP = 3;
 
-const RankingPage = () => {
-  const params = useParams<{ stageId: string }>();
-  const { stageId } = params;
+const supportsUntilFound = () =>
+  typeof document !== 'undefined' &&
+  document.body != null &&
+  'onbeforematch' in document.body;
 
-  const [topThreeRanks, setTopThreeRanks] = useState<RankItem[]>([]);
-  const listWrapperRef = useRef<HTMLDivElement>(null);
-  const [listHeight, setListHeight] = useState(MIN_LIST_HEIGHT);
-  const backendPagesRef = useRef<Map<number, Promise<RankingData>>>(new Map());
+const findScroller = (root: HTMLElement): HTMLElement | null => {
+  const candidates = root.querySelectorAll<HTMLElement>('*');
+  for (const el of Array.from(candidates)) {
+    const style = getComputedStyle(el);
+    if (style.overflowY === 'auto' || style.overflowY === 'scroll') return el;
+  }
+  return null;
+};
+
+const SearchableRow = ({ index, rank }: { index: number; rank: RankItem }) => {
+  const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    backendPagesRef.current = new Map();
-  }, [stageId]);
+    ref.current?.setAttribute('hidden', 'until-found');
+  }, []);
+
+  return (
+    <div ref={ref} data-index={index}>
+      {rank.rank}등 {rank.name}
+    </div>
+  );
+};
+
+const RankingPage = () => {
+  const { stageId } = useParams<{ stageId: string }>();
+
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useInfiniteQuery({
+      queryKey: ['ranking', stageId],
+      queryFn: ({ pageParam }) => getRank(stageId, pageParam, PAGE_SIZE),
+      initialPageParam: 0,
+      getNextPageParam: (last, pages) =>
+        last.rank.length === PAGE_SIZE ? pages.length : undefined,
+    });
+
+  const { data: fullData, refetch: fetchAll } = useQuery({
+    queryKey: ['ranking-all', stageId],
+    queryFn: () => getRank(stageId, 0, ALL_PAGE_SIZE),
+    enabled: false,
+    staleTime: 60_000,
+  });
+
+  const allRanks = useMemo<RankItem[]>(
+    () => fullData?.rank ?? data?.pages.flatMap((p) => p.rank) ?? [],
+    [data, fullData],
+  );
+  const topThree = useMemo(() => allRanks.slice(0, SKIP_TOP), [allRanks]);
+  const remaining = useMemo(() => allRanks.slice(SKIP_TOP), [allRanks]);
+  const reorderedTopThree = useMemo<RankItem[]>(
+    () =>
+      topThree.length >= SKIP_TOP
+        ? [topThree[1], topThree[0], topThree[2]]
+        : topThree,
+    [topThree],
+  );
+
+  const listWrapperRef = useRef<HTMLDivElement>(null);
+  const searchLayerRef = useRef<HTMLDivElement>(null);
+  const scrollerRef = useRef<HTMLElement | null>(null);
+  const [listHeight, setListHeight] = useState(MIN_LIST_HEIGHT);
+  const [canRenderSidecar, setCanRenderSidecar] = useState(false);
+
+  useEffect(() => {
+    setCanRenderSidecar(supportsUntilFound());
+  }, []);
 
   useLayoutEffect(() => {
     const compute = () => {
@@ -57,142 +117,66 @@ const RankingPage = () => {
     return () => window.removeEventListener('resize', compute);
   }, []);
 
-  const getBackendPage = useCallback(
-    (page: number) => {
-      let promise = backendPagesRef.current.get(page);
-      if (!promise) {
-        promise = getRank(stageId, page, PAGE_SIZE).catch((err) => {
-          backendPagesRef.current.delete(page);
-          throw err;
+  const fullDataRef = useRef(fullData);
+  fullDataRef.current = fullData;
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (!((e.metaKey || e.ctrlKey) && e.key === 'f')) return;
+      if (fullDataRef.current) return;
+      fetchAll();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [fetchAll]);
+
+  useEffect(() => {
+    const layer = searchLayerRef.current;
+    const wrapper = listWrapperRef.current;
+    if (!layer || !wrapper) return;
+
+    const onBeforeMatch = (e: Event) => {
+      const target = e.target as HTMLElement;
+      const idx = Number(target.dataset.index);
+      if (!Number.isFinite(idx)) return;
+
+      if (!scrollerRef.current) {
+        scrollerRef.current = findScroller(wrapper);
+      }
+
+      setTimeout(() => {
+        scrollerRef.current?.scrollTo({
+          top: idx * ITEM_HEIGHT,
+          behavior: 'smooth',
         });
-        backendPagesRef.current.set(page, promise);
+        target.setAttribute('hidden', 'until-found');
+      }, 0);
+    };
+
+    layer.addEventListener('beforematch', onBeforeMatch, true);
+    return () => layer.removeEventListener('beforematch', onBeforeMatch, true);
+  }, [canRenderSidecar]);
+
+  const handleRangeChange = useCallback(
+    ({ endIndex }: { startIndex: number; endIndex: number }) => {
+      if (
+        hasNextPage &&
+        !isFetchingNextPage &&
+        endIndex >= remaining.length - PAGE_SIZE / 2
+      ) {
+        fetchNextPage();
       }
-      return promise;
     },
-    [stageId],
+    [hasNextPage, isFetchingNextPage, remaining.length, fetchNextPage],
   );
-
-  const fetchPage = useCallback(
-    async (page: number, size: number): Promise<PageResponse<RankItem>> => {
-      const MAX_ATTEMPTS = 3;
-      let lastError: unknown;
-      for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
-        try {
-          const startIdx = SKIP_TOP + page * size;
-          const firstBackendPage = Math.floor(startIdx / size);
-          const offset = startIdx - firstBackendPage * size;
-
-          const [first, second] = await Promise.all([
-            getBackendPage(firstBackendPage),
-            getBackendPage(firstBackendPage + 1),
-          ]);
-          let items = first.rank.slice(offset);
-          if (items.length < size) {
-            items = items.concat(second.rank.slice(0, size - items.length));
-          }
-
-          if (page === 0 && first.rank.length >= SKIP_TOP) {
-            setTopThreeRanks(first.rank.slice(0, SKIP_TOP));
-          }
-
-          const hasMore = items.length === size;
-          const loadedEnd = page * size + items.length;
-
-          return {
-            items,
-            total: hasMore ? loadedEnd + size : loadedEnd,
-            hasMore,
-          };
-        } catch (error) {
-          lastError = error;
-          if (attempt < MAX_ATTEMPTS - 1) {
-            await new Promise((r) => setTimeout(r, 300 * (attempt + 1)));
-          }
-        }
-      }
-      throw lastError;
-    },
-    [getBackendPage],
-  );
-
-  const reorderedTopThreeRanks: RankItem[] =
-    topThreeRanks.length >= 3
-      ? [topThreeRanks[1], topThreeRanks[0], topThreeRanks[2]]
-      : topThreeRanks;
 
   const renderItem = useCallback(
-    (item: RankItem | undefined, _index: number, style: CSSProperties) => {
-      if (!item) {
-        return (
-          <div style={style}>
-            <div
-              className={cn(
-                'w-full',
-                'h-[3.75rem]',
-                'px-24',
-                'py-12',
-                'flex',
-                'justify-between',
-                'bg-gray-700',
-                'rounded-lg',
-                'items-center',
-                'animate-pulse',
-              )}
-            />
-          </div>
-        );
-      }
-
-      return (
-        <div style={style}>
-          <MemoRankingUserItem rank={item} />
-        </div>
-      );
-    },
-    [],
-  );
-
-  const renderLoading = useCallback(
-    () => (
-      <div className={cn('flex', 'items-center', 'justify-center', 'h-full')}>
-        <p className={cn('text-gray-400', 'text-body2s')}>로딩 중...</p>
+    (index: number, style: CSSProperties) => (
+      <div style={style}>
+        <MemoRankingUserItem rank={remaining[index]} />
       </div>
     ),
-    [],
-  );
-
-  const renderEmpty = useCallback(
-    () => (
-      <div className={cn('flex', 'items-center', 'justify-center', 'h-full')}>
-        <p className={cn('text-gray-400', 'text-body2s')}>
-          랭킹 데이터가 없습니다.
-        </p>
-      </div>
-    ),
-    [],
-  );
-
-  const renderError = useCallback(
-    (_error: Error, retry: () => void) => (
-      <div
-        className={cn(
-          'flex',
-          'flex-col',
-          'items-center',
-          'justify-center',
-          'h-full',
-          'gap-4',
-        )}
-      >
-        <p className={cn('text-gray-400', 'text-body2s')}>
-          에러가 발생했습니다.
-        </p>
-        <button onClick={retry} className={cn('text-main-400', 'text-body2s')}>
-          다시 시도
-        </button>
-      </div>
-    ),
-    [],
+    [remaining],
   );
 
   return (
@@ -207,22 +191,42 @@ const RankingPage = () => {
     >
       <BackPageButton label="포인트 랭킹" type="back" />
       <div className={cn('space-y-[2.25rem]')}>
-        <TopRankListContainer topRanks={reorderedTopThreeRanks} />
+        <TopRankListContainer topRanks={reorderedTopThree} />
         <div ref={listWrapperRef}>
-          <InfiniteList<RankItem>
-            fetchPage={fetchPage}
-            renderItem={renderItem}
+          <VirtualList
+            count={remaining.length}
             itemSize={ITEM_HEIGHT}
-            pageSize={PAGE_SIZE}
             height={listHeight}
-            overscan={20}
-            prefetchThreshold={3}
+            overscan={10}
             className="scroll-hidden"
-            renderLoading={renderLoading}
-            renderEmpty={renderEmpty}
-            renderError={renderError}
+            renderItem={renderItem}
+            onRangeChange={handleRangeChange}
           />
         </div>
+        {canRenderSidecar && (
+          <div
+            ref={searchLayerRef}
+            aria-hidden="true"
+            style={{
+              position: 'fixed',
+              top: 0,
+              left: 0,
+              width: 1,
+              height: 1,
+              padding: 0,
+              margin: 0,
+              overflow: 'hidden',
+              clip: 'rect(0, 0, 0, 0)',
+              whiteSpace: 'nowrap',
+              border: 0,
+              pointerEvents: 'none',
+            }}
+          >
+            {remaining.map((rank, i) => (
+              <SearchableRow key={rank.studentId} index={i} rank={rank} />
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/views/ranking/ui/RankingPage/index.tsx
+++ b/src/views/ranking/ui/RankingPage/index.tsx
@@ -1,87 +1,166 @@
 'use client';
 
+import dynamic from 'next/dynamic';
 import { useParams } from 'next/navigation';
-import React, { useEffect, useRef, useState, useCallback } from 'react';
+import React, {
+  useCallback,
+  useLayoutEffect,
+  useRef,
+  useState,
+  CSSProperties,
+} from 'react';
+import { RankingUserItem } from '@/entities/ranking';
 import { RankItem } from '@/shared/types/ranking';
 import BackPageButton from '@/shared/ui/backPageButton';
 import { cn } from '@/shared/utils/cn';
-import { RankingUserContainer, TopRankListContainer } from '@/widgets/ranking';
-import { useGetRankingQuery } from '../../model/useGetRankingQuery';
+import { TopRankListContainer } from '@/widgets/ranking';
+import { getRank } from '../../api/getRank';
+import type { PageResponse } from 'scrolloop';
+
+const MemoRankingUserItem = React.memo(RankingUserItem);
+
+const InfiniteList = dynamic(
+  () => import('scrolloop').then((mod) => mod.InfiniteList),
+  { ssr: false },
+) as <T>(props: import('scrolloop').InfiniteListProps<T>) => JSX.Element;
+
+const ITEM_HEIGHT = 76;
+const PAGE_SIZE = 10;
+const MIN_LIST_HEIGHT = 300;
+const LIST_BOTTOM_GAP = 24;
 
 const RankingPage = () => {
   const params = useParams<{ stageId: string }>();
   const { stageId } = params;
 
-  const [page, setPage] = useState(0);
-  const size = 10;
-  const [allRanks, setAllRanks] = useState<RankItem[]>([]);
-  const [isLastPage, setIsLastPage] = useState(false);
+  const [topThreeRanks, setTopThreeRanks] = useState<RankItem[]>([]);
+  const listWrapperRef = useRef<HTMLDivElement>(null);
+  const [listHeight, setListHeight] = useState(MIN_LIST_HEIGHT);
 
-  const { data, isFetching } = useGetRankingQuery(stageId, page, size);
+  useLayoutEffect(() => {
+    const compute = () => {
+      const el = listWrapperRef.current;
+      if (!el) return;
+      const top = el.getBoundingClientRect().top;
+      const available = window.innerHeight - top - LIST_BOTTOM_GAP;
+      setListHeight(Math.max(MIN_LIST_HEIGHT, available));
+    };
+    compute();
+    window.addEventListener('resize', compute);
+    return () => window.removeEventListener('resize', compute);
+  }, []);
 
-  const observerRef = useRef<HTMLDivElement | null>(null);
-  const prevScrollYRef = useRef(0);
+  const fetchPage = useCallback(
+    async (page: number, size: number): Promise<PageResponse<RankItem>> => {
+      const MAX_ATTEMPTS = 3;
+      let lastError: unknown;
+      for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+        try {
+          const data = await getRank(stageId, page, size);
 
-  const handleObserver = useCallback(
-    (entries: IntersectionObserverEntry[]) => {
-      const [entry] = entries;
-      if (entry.isIntersecting && !isFetching && !isLastPage) {
-        prevScrollYRef.current = window.scrollY;
-        setPage((prev) => prev + 1);
+          if (page === 0 && data.rank.length >= 3) {
+            setTopThreeRanks(data.rank.slice(0, 3));
+          }
+
+          const hasMore = data.rank.length === size;
+          const loadedEnd = page * size + data.rank.length;
+
+          return {
+            items: data.rank,
+            total: hasMore ? loadedEnd + size : loadedEnd,
+            hasMore,
+          };
+        } catch (error) {
+          lastError = error;
+          if (attempt < MAX_ATTEMPTS - 1) {
+            await new Promise((r) => setTimeout(r, 300 * (attempt + 1)));
+          }
+        }
       }
+      throw lastError;
     },
-    [isFetching],
+    [stageId],
   );
 
-  useEffect(() => {
-    const observer = new IntersectionObserver(handleObserver, {
-      root: null,
-      rootMargin: '0px',
-      threshold: 1.0,
-    });
+  const reorderedTopThreeRanks: RankItem[] =
+    topThreeRanks.length >= 3
+      ? [topThreeRanks[1], topThreeRanks[0], topThreeRanks[2]]
+      : topThreeRanks;
 
-    if (observerRef.current) {
-      observer.observe(observerRef.current);
-    }
-
-    return () => {
-      if (observerRef.current) {
-        observer.unobserve(observerRef.current);
-      }
-    };
-  }, [handleObserver]);
-
-  useEffect(() => {
-    if (data?.rank) {
-      setAllRanks((prev) => {
-        const newItems = data.rank.filter(
-          (item) =>
-            !prev.find((prevItem) => prevItem.studentId === item.studentId),
+  const renderItem = useCallback(
+    (item: RankItem | undefined, _index: number, style: CSSProperties) => {
+      if (!item) {
+        return (
+          <div style={style}>
+            <div
+              className={cn(
+                'w-full',
+                'h-[3.75rem]',
+                'px-24',
+                'py-12',
+                'flex',
+                'justify-between',
+                'bg-gray-700',
+                'rounded-lg',
+                'items-center',
+                'animate-pulse',
+              )}
+            />
+          </div>
         );
+      }
 
-        // ✅ 새로 추가된 게 없다면 마지막 페이지로 판단
-        if (newItems.length === 0) {
-          setIsLastPage(true);
-        }
+      return (
+        <div style={style}>
+          <MemoRankingUserItem rank={item} />
+        </div>
+      );
+    },
+    [],
+  );
 
-        if (newItems.length > 0) {
-          requestAnimationFrame(() => {
-            window.scrollTo({ top: prevScrollYRef.current, behavior: 'auto' });
-          });
-        }
+  const renderLoading = useCallback(
+    () => (
+      <div className={cn('flex', 'items-center', 'justify-center', 'h-full')}>
+        <p className={cn('text-gray-400', 'text-body2s')}>로딩 중...</p>
+      </div>
+    ),
+    [],
+  );
 
-        return [...prev, ...newItems];
-      });
-    }
-  }, [data]);
+  const renderEmpty = useCallback(
+    () => (
+      <div className={cn('flex', 'items-center', 'justify-center', 'h-full')}>
+        <p className={cn('text-gray-400', 'text-body2s')}>
+          랭킹 데이터가 없습니다.
+        </p>
+      </div>
+    ),
+    [],
+  );
 
-  const topThreeRanks: RankItem[] = allRanks.slice(0, 3);
-  const reorderedTopThreeRanks: RankItem[] = [
-    topThreeRanks[1],
-    topThreeRanks[0],
-    topThreeRanks[2],
-  ];
-  const remainingRanks: RankItem[] = allRanks.slice(3);
+  const renderError = useCallback(
+    (_error: Error, retry: () => void) => (
+      <div
+        className={cn(
+          'flex',
+          'flex-col',
+          'items-center',
+          'justify-center',
+          'h-full',
+          'gap-4',
+        )}
+      >
+        <p className={cn('text-gray-400', 'text-body2s')}>
+          에러가 발생했습니다.
+        </p>
+        <button onClick={retry} className={cn('text-main-400', 'text-body2s')}>
+          다시 시도
+        </button>
+      </div>
+    ),
+    [],
+  );
 
   return (
     <div
@@ -96,8 +175,21 @@ const RankingPage = () => {
       <BackPageButton label="포인트 랭킹" type="back" />
       <div className={cn('space-y-[2.25rem]')}>
         <TopRankListContainer topRanks={reorderedTopThreeRanks} />
-        <RankingUserContainer remainingRanks={remainingRanks} />
-        <div ref={observerRef} className="h-10" />
+        <div ref={listWrapperRef}>
+          <InfiniteList<RankItem>
+            fetchPage={fetchPage}
+            renderItem={renderItem}
+            itemSize={ITEM_HEIGHT}
+            pageSize={PAGE_SIZE}
+            height={listHeight}
+            overscan={20}
+            prefetchThreshold={3}
+            className="scroll-hidden"
+            renderLoading={renderLoading}
+            renderEmpty={renderEmpty}
+            renderError={renderError}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/views/ranking/ui/RankingPage/index.tsx
+++ b/src/views/ranking/ui/RankingPage/index.tsx
@@ -4,13 +4,14 @@ import dynamic from 'next/dynamic';
 import { useParams } from 'next/navigation';
 import React, {
   useCallback,
+  useEffect,
   useLayoutEffect,
   useRef,
   useState,
   CSSProperties,
 } from 'react';
 import { RankingUserItem } from '@/entities/ranking';
-import { RankItem } from '@/shared/types/ranking';
+import { RankItem, RankingData } from '@/shared/types/ranking';
 import BackPageButton from '@/shared/ui/backPageButton';
 import { cn } from '@/shared/utils/cn';
 import { TopRankListContainer } from '@/widgets/ranking';
@@ -28,6 +29,7 @@ const ITEM_HEIGHT = 76;
 const PAGE_SIZE = 10;
 const MIN_LIST_HEIGHT = 300;
 const LIST_BOTTOM_GAP = 24;
+const SKIP_TOP = 3;
 
 const RankingPage = () => {
   const params = useParams<{ stageId: string }>();
@@ -36,6 +38,11 @@ const RankingPage = () => {
   const [topThreeRanks, setTopThreeRanks] = useState<RankItem[]>([]);
   const listWrapperRef = useRef<HTMLDivElement>(null);
   const [listHeight, setListHeight] = useState(MIN_LIST_HEIGHT);
+  const backendPagesRef = useRef<Map<number, Promise<RankingData>>>(new Map());
+
+  useEffect(() => {
+    backendPagesRef.current = new Map();
+  }, [stageId]);
 
   useLayoutEffect(() => {
     const compute = () => {
@@ -50,23 +57,49 @@ const RankingPage = () => {
     return () => window.removeEventListener('resize', compute);
   }, []);
 
+  const getBackendPage = useCallback(
+    (page: number) => {
+      let promise = backendPagesRef.current.get(page);
+      if (!promise) {
+        promise = getRank(stageId, page, PAGE_SIZE).catch((err) => {
+          backendPagesRef.current.delete(page);
+          throw err;
+        });
+        backendPagesRef.current.set(page, promise);
+      }
+      return promise;
+    },
+    [stageId],
+  );
+
   const fetchPage = useCallback(
     async (page: number, size: number): Promise<PageResponse<RankItem>> => {
       const MAX_ATTEMPTS = 3;
       let lastError: unknown;
       for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
         try {
-          const data = await getRank(stageId, page, size);
+          const startIdx = SKIP_TOP + page * size;
+          const firstBackendPage = Math.floor(startIdx / size);
+          const offset = startIdx - firstBackendPage * size;
 
-          if (page === 0 && data.rank.length >= 3) {
-            setTopThreeRanks(data.rank.slice(0, 3));
+          const [first, second] = await Promise.all([
+            getBackendPage(firstBackendPage),
+            getBackendPage(firstBackendPage + 1),
+          ]);
+          let items = first.rank.slice(offset);
+          if (items.length < size) {
+            items = items.concat(second.rank.slice(0, size - items.length));
           }
 
-          const hasMore = data.rank.length === size;
-          const loadedEnd = page * size + data.rank.length;
+          if (page === 0 && first.rank.length >= SKIP_TOP) {
+            setTopThreeRanks(first.rank.slice(0, SKIP_TOP));
+          }
+
+          const hasMore = items.length === size;
+          const loadedEnd = page * size + items.length;
 
           return {
-            items: data.rank,
+            items,
             total: hasMore ? loadedEnd + size : loadedEnd,
             hasMore,
           };
@@ -79,7 +112,7 @@ const RankingPage = () => {
       }
       throw lastError;
     },
-    [stageId],
+    [getBackendPage],
   );
 
   const reorderedTopThreeRanks: RankItem[] =


### PR DESCRIPTION
## 💡 배경 및 개요

기존 랭킹 페이지의 IntersectionObserver 기반 무한 스크롤을 가상화 기반 리스트로 교체합니다. 항목이 많아질수록 DOM 노드가 누적되어 렌더링/스크롤 성능이 저하되는 문제를 해결하기 위해, 뷰포트에 보이는 항목만 렌더링하는 scrolloop의 InfiniteList를 도입했습니다

## 📃 작업내용

리스트 높이를 useLayoutEffect로 뷰포트 남은 공간에 맞춰 동적 계산, 아이템 렌더링은 기존 RankingUserItem 엔티티 컴포넌트를 React.memo로 감싸 재사용
